### PR TITLE
chore: add displayName for Zig

### DIFF
--- a/sources-grammars.ts
+++ b/sources-grammars.ts
@@ -891,6 +891,7 @@ export const sourcesCommunity: GrammarSource[] = [
   },
   {
     name: 'zig',
+    displayName: 'Zig',
     source: 'https://github.com/ziglang/vscode-zig/blob/master/syntaxes/zig.tmLanguage.json',
     categories: ['general'],
   },


### PR DESCRIPTION
Zig is capitalized in all of the branding for the language (https://ziglang.org/).