### PR TITLE
fix(playground): disable spellcheck on code editor

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -307,6 +307,7 @@ if (import.meta.hot) {
             id="input"
             v-model="input"
             class="absolute top-0 left-0 inset-0 caret-gray w-full h-full resize-none of-hidden p4 bg-transparent z-1 font-mono text-transparent"
+            spellcheck="false"
           />
         </div>
       </div>


### PR DESCRIPTION
Disables spellcheck in the playground's code editor:

![Screenshot 2024-05-12 at 15 36 19 (Arc)](https://github.com/shikijs/textmate-grammars-themes/assets/47499684/0205634c-55a2-4463-b6e4-45aa86ab5e1b)
