### PR TITLE
fix: Use hex color "#FFFFFF" instead of "white" in one-light theme.

### DIFF
--- a/packages/tm-themes/themes/one-light.json
+++ b/packages/tm-themes/themes/one-light.json
@@ -541,7 +541,7 @@
       ],
       "settings": {
         "background": "#FF1414",
-        "foreground": "white"
+        "foreground": "#FFFFFF"
       }
     },
     {


### PR DESCRIPTION
This enable `colorReplacements` option to replace `white` color specified in one-light theme.