### PR TITLE
fix: consistent font family in editor

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -389,4 +389,7 @@ if (import.meta.hot) {
 .panel-info button {
   --uno: hover-text-primary hover-underline hover:op100;
 }
+pre code {
+  --uno: font-mono;
+}
 </style>


### PR DESCRIPTION
On Windows, the background font of the code editor is `Consolas`, while the transparent textarea uses a slightly wider `DM Mono` font, resulting in misplaced text.

The background of the code editor is set to the same font as the textarea.