### PR TITLE
fix(night-owl): allow highlight and diff transforms with `shiki`

### DIFF
--- a/packages/tm-themes/themes/night-owl.json
+++ b/packages/tm-themes/themes/night-owl.json
@@ -246,7 +246,7 @@
       }
     },
     {
-      "scope": "comment",
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
         "fontStyle": "italic",
         "foreground": "#637777"


### PR DESCRIPTION
Fix to make highlight and diff transforms work with the `night-owl` theme.