### PR TITLE
feat: combohash highlighter for cyber security professionals

### DIFF
--- a/packages/tm-grammars/grammars/combohash.json
+++ b/packages/tm-grammars/grammars/combohash.json
@@ -1,0 +1,54 @@
+{
+    "displayName": "Combo Hash",
+    "fileTypes": [
+      "combo",
+      "hash",
+      "hashes"
+    ],
+    "foldingStartMarker": "--next",
+    "foldingStopMarker": "\\n\\n",
+    "name": "combohash",
+    "patterns": [
+      {
+        "captures": {
+          "1": {
+            "name": "variable.username.combo"
+          },
+          "2": {
+            "name": "punctuation.separator.colon.combo"
+          },
+          "3": {
+            "name": "string.password.combo"
+          }
+        },
+        "match": "^(\\w+)?(:)(.+?)(?=\\s*#|$)"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "keyword.hash.dollar"
+          }
+        },
+        "match": "\\$"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "constant.numeric.hash"
+          }
+        },
+        "match": "^\\d+"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "comment.line.number-sign.combohash"
+          }
+        },
+        "match": "\\s*(#).*$",
+        "name": "comment.line.combohash"
+      }
+    ],
+    "scopeName": "source.combohash"
+  }
+  

--- a/packages/tm-grammars/raw/combohash.json
+++ b/packages/tm-grammars/raw/combohash.json
@@ -1,0 +1,54 @@
+{
+    "displayName": "Combo Hash",
+    "fileTypes": [
+      "combo",
+      "hash",
+      "hashes"
+    ],
+    "foldingStartMarker": "--next",
+    "foldingStopMarker": "\\n\\n",
+    "name": "combohash",
+    "patterns": [
+      {
+        "captures": {
+          "1": {
+            "name": "variable.username.combo"
+          },
+          "2": {
+            "name": "punctuation.separator.colon.combo"
+          },
+          "3": {
+            "name": "string.password.combo"
+          }
+        },
+        "match": "^(\\w+)?(:)(.+?)(?=\\s*#|$)"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "keyword.hash.dollar"
+          }
+        },
+        "match": "\\$"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "constant.numeric.hash"
+          }
+        },
+        "match": "^\\d+"
+      },
+      {
+        "captures": {
+          "1": {
+            "name": "comment.line.number-sign.combohash"
+          }
+        },
+        "match": "\\s*(#).*$",
+        "name": "comment.line.combohash"
+      }
+    ],
+    "scopeName": "source.combohash"
+  }
+  

--- a/samples/combohash.sample
+++ b/samples/combohash.sample
@@ -1,0 +1,4 @@
+user:1000::aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c:::
+user:8846f7eaee8fb117ad06bdd830b7586c
+user:$6$xyz$ShNnbwk5fmsyVIlzOf8zEg4YdEH2aWRSuY4rJHbzLZRlWcoXbxxoI0hfn0mdXiJCdBJ/lTpKjk.vu5NZOv0UM0
+user:$1$xyz$cEUv8aN9ehjhMXG/kSFnM1


### PR DESCRIPTION
The combohash highlight is a simple highlighter for penetration testers. For files in the format of 'username:password/hash # Comment' it will do higlighting. This is valuable for both penetration testers and their clients, as often work with an ever-growing list of credentials as we work our way through an enviroment during a penetration test.