### PR TITLE
feat: treat entire block as mermaid

### DIFF
--- a/packages/tm-grammars/grammars/mermaid.json
+++ b/packages/tm-grammars/grammars/mermaid.json
@@ -13,6 +13,9 @@
     },
     {
       "include": "#mermaid-ado-code-block"
+    },
+    {
+      "include": "#mermaid"
     }
   ],
   "repository": {


### PR DESCRIPTION
Previously, a code block was required to treat the code as mermaid. This does away with that requirement.

Before:
<img width="539" alt="image" src="https://github.com/user-attachments/assets/9af7cef6-35a6-4b81-b1de-d74a5f061561" />

After:
<img width="818" alt="image" src="https://github.com/user-attachments/assets/b32b570c-972f-45be-ac8e-e838a133a22e" />

I also did some adhoc testing that this doesn't break/change rendering between markdown code blocks.