### PR TITLE
fix(build): unbreak build via newer corepack

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@ publish = "playground/dist"
 command = "pnpm run play:build"
 
 [build.environment]
-NODE_VERSION = "20"
+NODE_VERSION = "22.14.0"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@ publish = "playground/dist"
 command = "pnpm run play:build"
 
 [build.environment]
-NODE_VERSION = "22.14.0"
+NODE_VERSION = "22"


### PR DESCRIPTION
Builds/deploys now have the following error ([example](https://app.netlify.com/sites/textmate-grammars-themes/deploys/67cafa225e698c0008196c23)):
```
9:53:08 PM: /opt/buildhome/.nvm/versions/node/v20.18.3/lib/node_modules/corepack/dist/lib/corepack.cjs:21535
9:53:08 PM:   if (key == null || signature == null) throw new Error(`Cannot find matching keyid: 
```

Found that updating to a newer version of node that includes a newer version of corepack resolves it, via [this thread](https://answers.netlify.com/t/corepack-and-pnpm-10-2-0-failing-on-build/138964/5).  [23.7.0 includes corepack 0.31](https://github.com/nodejs/node/releases/tag/v23.7.0) 

Full description of issue is at https://vercel.com/guides/corepack-errors-github-actions .