### PR TITLE
fix: update grammar url marko

### DIFF
--- a/sources-grammars.ts
+++ b/sources-grammars.ts
@@ -758,7 +758,7 @@ export const sourcesCommunity: GrammarSource[] = [
   },
   {
     name: 'marko',
-    source: 'https://github.com/marko-js/marko-tmbundle/blob/master/Syntaxes/marko.tmLanguage',
+    source: 'https://github.com/marko-js/language-server/blob/main/packages/vscode/syntaxes/marko.tmLanguage.json',
     categories: ['web', 'markup'],
   },
   {


### PR DESCRIPTION
The grammar at the existing location is out of date but there for ...reasons.
This PR updates the grammar to use the one used in the official marko vscode plugin.

Would be very grateful if we could get this in and released since we're using shiki heavily in our new Marko 6 website 😄 (https://next.markojs.com/)