### PR TITLE
feat: add funding buttons to playground

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@shikijs/core": "catalog:",
     "@vueuse/core": "catalog:",
+    "floating-vue": "catalog:",
     "vue": "catalog:",
     "vue-router": "catalog:"
   },

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -6,6 +6,7 @@ import { createOnigurumaEngine } from '@shikijs/engine-oniguruma'
 import { grammars, injections } from '../../packages/tm-grammars/index'
 import { themes } from '../../packages/tm-themes/index'
 import Badge from './Badge.vue'
+import FundingButton from './FundingButton.vue'
 import SegmentControl from './SegmentControl.vue'
 import { engine, engineJsForgiving, grammar, isDark, theme } from './state'
 
@@ -302,14 +303,7 @@ if (import.meta.hot) {
                 <button text-left @click="openGrammar()">
                   <code>{{ grammar }}</code>
                 </button>
-                <!-- TODO: Add funding links -->
-                <!-- <div text-xs>
-                  <span v-for="(link, index) in grammarObject?.funding" :key="index">
-                    <a :href="link.url" target="_blank" hover="text-pink" flex="~ items-center gap-1">
-                      <div i-carbon-favorite /> <b>{{ link.handle || link.name }}</b>
-                    </a>
-                  </span>
-                </div> -->
+                <FundingButton :name="`${grammarObject?.displayName} grammar`" :funding="grammarObject?.funding" />
               </div>
               <div v-if="embedded.length < 15" flex="~ col" ml-2 border="l base">
                 <div v-for="e in embedded" :key="e" flex="~ items-center gap-2">
@@ -333,14 +327,7 @@ if (import.meta.hot) {
                 <button text-left @click="openTheme()">
                   <code>{{ theme }}</code>
                 </button>
-                <!-- TODO: Add funding links -->
-                <!-- <div text-xs>
-                  <span v-for="(link, index) in grammarObject?.funding" :key="index">
-                    <a :href="link.url" target="_blank" hover="text-pink" flex="~ items-center gap-1">
-                      <div i-carbon-favorite /> <b>{{ link.handle || link.name }}</b>
-                    </a>
-                  </span>
-                </div> -->
+                <FundingButton :name="`${themeObject?.displayName} theme`" :funding="themeObject?.funding" />
               </div>
             </div>
             <div text-right op50>

--- a/playground/src/FundingButton.vue
+++ b/playground/src/FundingButton.vue
@@ -13,6 +13,13 @@ defineProps<{
     v-if="funding && funding.length > 0"
     class="group"
     relative flex
+    delay="0"
+    placement="bottom-start"
+    theme="dropdown"
+    :triggers="['hover', 'touch']"
+    :popper-triggers="['hover', 'touch']"
+    :overflow-padding="10"
+    :arrow-padding="8"
   >
     <button
       title="Funding"
@@ -28,7 +35,7 @@ defineProps<{
     </button>
 
     <template #popper>
-      <div p2 class="vp-doc text-sm">
+      <div p3 class="vp-doc text-sm">
         <strong block mb-2>Support {{ name }} development:</strong>
         <div
           v-for="link, i in funding"

--- a/playground/src/FundingButton.vue
+++ b/playground/src/FundingButton.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import type { FundingLink } from '../../packages/tm-grammars/index'
+import { Tooltip } from 'floating-vue'
+
+defineProps<{
+  funding: FundingLink[] | undefined
+  name: string
+}>()
+</script>
+
+<template>
+  <Tooltip
+    v-if="funding && funding.length > 0"
+    class="group"
+    relative flex
+  >
+    <button
+      title="Funding"
+      hover="bg-gray/10"
+      class="text-[10px] p-[3px]"
+      rounded
+    >
+      <div
+        i-carbon:favorite-filled
+        op25 group-hover:op100 group-focus-within:op100 group-hover:text-red-500
+        transition-opacity duration-250
+      />
+    </button>
+
+    <template #popper>
+      <div p2 class="vp-doc text-sm">
+        <strong block mb-2>Support {{ name }} development:</strong>
+        <div
+          v-for="link, i in funding"
+          :key="i"
+          text-nowrap
+        >
+          <template v-if="link.handle">
+            {{ link.name }}:
+          </template>
+          <a :href="link.url" target="_blank" text-primary underline hover:no-underline>{{ link.handle || link.name }}</a>
+        </div>
+      </div>
+    </template>
+  </Tooltip>
+</template>

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -1,3 +1,4 @@
+import FloatingVue from 'floating-vue'
 import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
 import { routes } from 'vue-router/auto-routes'
@@ -5,11 +6,32 @@ import App from './App.vue'
 
 import '@unocss/reset/tailwind.css'
 import 'uno.css'
+import 'floating-vue/dist/style.css'
+
+const isMobile = typeof navigator !== 'undefined' && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
 
 const app = createApp(App)
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes,
+})
+app.use(FloatingVue, {
+  themes: {
+    tooltip: {
+      $extend: 'dropdown',
+      triggers: isMobile ? ['touch'] : ['hover', 'touch'],
+      popperTriggers: isMobile ? ['touch'] : ['hover', 'touch'],
+      placement: 'bottom-start',
+      overflowPadding: 10,
+      delay: 0,
+      handleResize: false,
+      autoHide: true,
+      instantMove: true,
+      flip: false,
+      arrowPadding: 8,
+      autoBoundaryMaxSize: true,
+    },
+  },
 })
 app.use(router)
 app.mount('#app')

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -8,30 +8,11 @@ import '@unocss/reset/tailwind.css'
 import 'uno.css'
 import 'floating-vue/dist/style.css'
 
-const isMobile = typeof navigator !== 'undefined' && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
-
 const app = createApp(App)
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes,
 })
-app.use(FloatingVue, {
-  themes: {
-    tooltip: {
-      $extend: 'dropdown',
-      triggers: isMobile ? ['touch'] : ['hover', 'touch'],
-      popperTriggers: isMobile ? ['touch'] : ['hover', 'touch'],
-      placement: 'bottom-start',
-      overflowPadding: 10,
-      delay: 0,
-      handleResize: false,
-      autoHide: true,
-      instantMove: true,
-      flip: false,
-      arrowPadding: 8,
-      autoBoundaryMaxSize: true,
-    },
-  },
-})
+app.use(FloatingVue)
 app.use(router)
 app.mount('#app')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ catalogs:
     fast-plist:
       specifier: ^0.1.3
       version: 0.1.3
+    floating-vue:
+      specifier: ^5.2.2
+      version: 5.2.2
     js-yaml:
       specifier: ^4.1.0
       version: 4.1.0
@@ -330,6 +333,9 @@ importers:
       '@vueuse/core':
         specifier: 'catalog:'
         version: 13.5.0(vue@3.5.17(typescript@5.8.3))
+      floating-vue:
+        specifier: 'catalog:'
+        version: 5.2.2(vue@3.5.17(typescript@5.8.3))
       vue:
         specifier: 'catalog:'
         version: 3.5.17(typescript@5.8.3)
@@ -880,6 +886,15 @@ packages:
   '@eslint/plugin-kit@0.3.1':
     resolution: {integrity: sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.1.1':
+    resolution: {integrity: sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==}
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2816,6 +2831,15 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  floating-vue@5.2.2:
+    resolution: {integrity: sha512-afW+h2CFafo+7Y9Lvw/xsqjaQlKLdJV7h1fCHfcYQ1C4SVMlu7OAekqWgu5d4SgvkBVU0pVpLlVsrSTBURFRkg==}
+    peerDependencies:
+      '@nuxt/kit': ^3.2.0
+      vue: ^3.2.0
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
@@ -4302,6 +4326,11 @@ packages:
     peerDependencies:
       vue: ^3.4.37
 
+  vue-resize@2.0.0-alpha.1:
+    resolution: {integrity: sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==}
+    peerDependencies:
+      vue: ^3.0.0
+
   vue-router@4.5.1:
     resolution: {integrity: sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==}
     peerDependencies:
@@ -4750,6 +4779,16 @@ snapshots:
     dependencies:
       '@eslint/core': 0.14.0
       levn: 0.4.1
+
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.1.1':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+
+  '@floating-ui/utils@0.2.10': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -7050,6 +7089,12 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  floating-vue@5.2.2(vue@3.5.17(typescript@5.8.3)):
+    dependencies:
+      '@floating-ui/dom': 1.1.1
+      vue: 3.5.17(typescript@5.8.3)
+      vue-resize: 2.0.0-alpha.1(vue@3.5.17(typescript@5.8.3))
+
   foreground-child@3.3.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -8838,6 +8883,10 @@ snapshots:
       - supports-color
 
   vue-flow-layout@0.1.1(vue@3.5.17(typescript@5.8.3)):
+    dependencies:
+      vue: 3.5.17(typescript@5.8.3)
+
+  vue-resize@2.0.0-alpha.1(vue@3.5.17(typescript@5.8.3)):
     dependencies:
       vue: 3.5.17(typescript@5.8.3)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - playground
   - packages/*
   - examples/*
+
 catalog:
   '@antfu/eslint-config': ^4.16.2
   '@antfu/ni': ^25.0.0
@@ -33,6 +34,7 @@ catalog:
   esno: ^4.8.0
   fast-glob: ^3.3.3
   fast-plist: ^0.1.3
+  floating-vue: ^5.2.2
   js-yaml: ^4.1.0
   json-stable-stringify: ^1.3.0
   jsonc-parser: ^3.3.1
@@ -61,6 +63,7 @@ catalog:
   vue-router: ^4.5.1
   vue-tsc: ^3.0.1
   yaml: ^2.8.0
+
 onlyBuiltDependencies:
   - esbuild
   - simple-git-hooks


### PR DESCRIPTION
Towards https://github.com/shikijs/shiki/issues/906:

Copied the `FundingButton` component from https://github.com/shikijs/shiki/pull/1052. Let me know if there is a better way to share the code – but it's not a very complex component so might be fine to duplicate it, IMO.

<img width="659" height="244" alt="image" src="https://github.com/user-attachments/assets/d9f28aae-b547-4f0a-adab-dcd2242bfff3" />
