### PR TITLE
Add nextflow-groovy

### DIFF
--- a/sources-grammars.ts
+++ b/sources-grammars.ts
@@ -825,6 +825,10 @@ export const sourcesCommunity: GrammarSource[] = [
     source: 'https://github.com/liana-p/narrat-syntax-highlighting-vscode/blob/main/syntaxes/narrat.tmLanguage.yaml',
   },
   {
+    name: 'nextflow-groovy',
+    source: 'https://github.com/nextflow-io/vscode-language-nextflow/blob/main/syntaxes/groovy.tmLanguage.json',
+  },
+  {
     name: 'nextflow',
     aliases: ['nf'],
     source: 'https://github.com/nextflow-io/vscode-language-nextflow/blob/main/syntaxes/nextflow.tmLanguage.json',


### PR DESCRIPTION
The nextflow syntax refers to it and is from the same repo. I think it's mostly meant to be embedded in nextflow so i haven't added a sample/license for that library.