### PR TITLE
feat: add justfile alias to just language

### DIFF
--- a/sources-grammars.ts
+++ b/sources-grammars.ts
@@ -775,6 +775,7 @@ export const sourcesCommunity: GrammarSource[] = [
   {
     name: 'just',
     displayName: 'Just',
+    aliases: ['justfile'],
     source: 'https://github.com/nefrob/vscode-just/blob/main/syntaxes/just.tmLanguage.json',
   },
   {


### PR DESCRIPTION
Add "justfile" as an alias for the just language grammar.

Rationale:
As seen in the [official repository](https://github.com/casey/just/blob/master/justfile), `justfile` is the most commonly used filename for defining tasks in the Just language.
People sometimes refer to the language itself as "justfile" to distinguish it from the English word "just."
