### PR TITLE
feat: add `pwsh` as alias to PowerShell

### DIFF
--- a/sources-grammars.ts
+++ b/sources-grammars.ts
@@ -260,7 +260,7 @@ export const sourcesVSCode: GrammarSource[] = [
   },
   {
     name: 'powershell',
-    aliases: ['ps', 'ps1'],
+    aliases: ['ps', 'ps1', 'pwsh'],
     source: 'https://github.com/microsoft/vscode/blob/main/extensions/powershell/syntaxes/powershell.tmLanguage.json',
   },
   {


### PR DESCRIPTION
> I first created a PR in wrong repo: <https://github.com/shikijs/shiki/pull/1252>

### Description

Add `pwsh` as alias for `powershell`.

### Linked Issues

* <https://github.com/mProjectsCode/obsidian-shiki-plugin/issues/68>

### Additional context

`pwsh` is the name of the executable ever since Dotnet Core (cross platform) was created, and PowerShell Core (cross platform) was made on top of it. Before that we had Windows PowerShell, with executable name `powershell`.

* Old Windows PowerShell: `powershell`
* New PowerShell: `pwsh`

Other code highlighters supports `pwsh` as alias for `powershell`.

* Chroma: <https://github.com/alecthomas/chroma/blob/10daf0405b1352a692381221d9634d716e65a0cc/lexers/embedded/powershell.xml#L9>
* GitHub linguist: <https://github.com/github-linguist/linguist/blob/738a27e1e2f26f061a24e94f85cd37ae9be71105/lib/linguist/languages.yml#L5923-L5939>
* Highlight.js: <https://github.com/highlightjs/highlight.js/blob/main/src%2Flanguages%2Fpowershell.js>
* Pygments: <https://github.com/pygments/pygments/blob/28ec10c5e154ee27201997feb573a0b065f74082/pygments/lexers/shell.py#L645>
* Rouge: <https://github.com/rouge-ruby/rouge/blob/1e3f8f9cabec5f7d5a8a02a75a92b37d007b03c7/lib/rouge/lexers/powershell.rb#L11>