### PR TITLE
feat: update Mojo grammar source

### DIFF
--- a/sources-grammars.ts
+++ b/sources-grammars.ts
@@ -848,7 +848,7 @@ export const sourcesCommunity: GrammarSource[] = [
   {
     name: 'mojo',
     displayName: 'Mojo',
-    source: 'https://github.com/modularml/mojo-syntax/blob/main/syntaxes/mojo.syntax.json',
+    source: 'https://github.com/modular/vscode-mojo/blob/main/syntaxes/mojo.syntax.json',
   },
   {
     name: 'move',


### PR DESCRIPTION
The `modular/mojo-syntax` repo will soon be deprecated now that `modular/vscode-mojo` is public. This changes the source for mojo grammar to `modular/vscode-mojo` which is more up to date.