### PR TITLE
feat: add `nsis` grammar

### DIFF
--- a/packages/tm-grammars/grammars/nsis.json
+++ b/packages/tm-grammars/grammars/nsis.json
@@ -6,9 +6,92 @@
     "bnsh",
     "nsdinc"
   ],
-  "displayName": "NSIS",
-  "name": "nsis",
+  "name": "NSIS",
   "patterns": [
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.nsis"
+        },
+        "2": {
+          "name": "entity.name.function.nsis"
+        }
+      },
+      "match": "^\\s*(?i)(Function)\\s+(\\.?\\w+)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.other.nsis"
+        },
+        "2": {
+          "name": "entity.name.function.macro.nsis"
+        }
+      },
+      "match": "^\\s*(?i)(!macro)\\s+(\\w+)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.other.nsis"
+        },
+        "2": {
+          "name": "entity.name.constant.define.nsis"
+        }
+      },
+      "match": "^\\s*(?i)(!define)\\s+(?:/\\w+\\s+)*(\\w+)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.nsis"
+        },
+        "2": {
+          "name": "entity.name.variable.nsis"
+        }
+      },
+      "match": "^\\s*(?i)(Var)\\s+(?:/GLOBAL\\s+)?\"?(\\w+)\"?"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.nsis"
+        },
+        "2": {
+          "name": "string.quoted.double.nsis"
+        },
+        "3": {
+          "name": "string.quoted.single.nsis"
+        },
+        "4": {
+          "name": "string.quoted.back.nsis"
+        },
+        "5": {
+          "name": "entity.name.section.nsis"
+        }
+      },
+      "match": "^\\s*(?i)(Section(?:Group)?)\\s+(?:/[eo]\\s+)?(?:(\"[^\"]*\")|('[^']*')|(`[^`]*`))\\s+(\\w+)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.nsis"
+        },
+        "2": {
+          "name": "entity.name.section.nsis string.quoted.double.nsis"
+        },
+        "3": {
+          "name": "entity.name.section.nsis string.quoted.single.nsis"
+        },
+        "4": {
+          "name": "entity.name.section.nsis string.quoted.back.nsis"
+        },
+        "5": {
+          "name": "entity.name.section.nsis"
+        }
+      },
+      "match": "^\\s*(?i)(Section(?:Group)?)\\s+(?:/[eo]\\s+)?(?:\"([^\"]+)\"|'([^']+)'|`([^`]+)`|([-.\\w]+))\\s*$"
+    },
     {
       "match": "^\\s*(?i)(Abort|AddBrandingImage|AddSize|AllowRootDirInstall|AllowSkipFiles|AutoCloseWindow|BGFont|BGGradient|BrandingText|BringToFront|Call|CallInstDLL|Caption|ChangeUI|CheckBitmap|ClearErrors|CompletedText|ComponentText|CopyFiles|CPU|CRCCheck|CreateDirectory|CreateFont|CreateShortCut|Delete|DeleteINISec|DeleteINIStr|DeleteRegKey|DeleteRegValue|DetailPrint|DetailsButtonText|DirText|DirVar|DirVerify|EnableWindow|EnumRegKey|EnumRegValue|Exch|Exec|ExecShell|ExecShellWait|ExecWait|ExpandEnvStrings|File|FileBufSize|FileClose|FileErrorText|FileOpen|FileRead|FileReadByte|FileReadUTF16LE|FileReadWord|FileWriteUTF16LE|FileSeek|FileWrite|FileWriteByte|FileWriteWord|FindClose|FindFirst|FindNext|FindWindow|FlushINI|Function(End)?|GetCurInstType|GetCurrentAddress|GetDlgItem|GetDLLVersion|GetDLLVersionLocal|GetErrorLevel|GetFileTime|GetFileTimeLocal|GetFullPathName|GetFunctionAddress|GetInstDirError|GetKnownFolderPath|GetLabelAddress|GetRegView|GetShellVarContext|GetTempFileName|GetWinVer|Goto|HideWindow|Icon|IfAbort|IfAltRegView|IfErrors|IfFileExists|IfRebootFlag|IfRtlLanguage|IfShellVarContextAll|IfSilent|InitPluginsDir|InstallButtonText|InstallColors|InstallDir|InstallDirRegKey|InstProgressFlags|InstType|InstTypeGetText|InstTypeSetText|Int64CmpU??|Int64Fmt|IntCmpU??|IntFmt|IntOp|IntPtrCmpU??|IntPtrOp|IsWindow|LangString|LicenseBkColor|LicenseData|LicenseForceSelection|LicenseLangString|LicenseText|LoadAndSetImage|LoadLanguageFile|LockWindow|LogSet|LogText|ManifestAppendCustomString|ManifestDisableWindowFiltering|ManifestDPIAware|ManifestGdiScaling|ManifestLongPathAware|ManifestMaxVersionTested|ManifestSupportedOS|MessageBox|MiscButtonText|Name|Nop|OutFile|Page|PageCallbacks|PageEx(End)?|PEAddResource|PEDllCharacteristics|PERemoveResource|PESubsysVer|Pop|Push|Quit|ReadEnvStr|ReadINIStr|ReadMemory|ReadRegDWORD|ReadRegStr|Reboot|RegDLL|Rename|RequestExecutionLevel|ReserveFile|Return|RMDir|SearchPath|Section(End)?|SectionGroup(End)?|SectionGetFlags|SectionGetInstTypes|SectionGetSize|SectionGetText|SectionIn|SectionSetFlags|SectionSetInstTypes|SectionSetSize|SectionSetText|SendMessage|SetAutoClose|SetBrandingImage|SetCompress|SetCompressionLevel|SetCompressor|SetCompressorDictSize|SetCtlColors|SetCurInstType|SetDatablockOptimize|SetDateSave|SetDetailsPrint|SetDetailsView|SetErrorLevel|SetErrors|SetFileAttributes|SetFont|SetOutPath|SetOverwrite|SetRebootFlag|SetRegView|SetShellVarContext|SetSilent|ShowInstDetails|ShowUninstDetails|ShowWindow|SilentInstall|SilentUnInstall|Sleep|SpaceTexts|StrCmpS??|StrCpy|StrLen|SubCaption|Target|Unicode|UninstallButtonText|UninstallCaption|UninstallIcon|UninstallSubCaption|UninstallText|UninstPage|UnRegDLL|UnsafeStrCpy|Var|VIAddVersionKey|VIFileVersion|VIProductVersion|WindowIcon|WriteINIStr|WriteRegBin|WriteRegDWORD|WriteRegExpandStr|WriteRegMultiStr|WriteRegNone|WriteRegStr|WriteUninstaller|XPStyle)\\b",
       "name": "keyword.nsis"
@@ -58,31 +141,31 @@
       "name": "constant.numeric.nsis"
     },
     {
-      "match": "^\\s*(?i)\\$\\{(BannerTrimPath|DirState|DriveSpace|Get(BaseName|Drives|ExeName|ExePath|FileAttributes|FileExt|FileName|FileVersion|OptionsS??|Parameters|Parent|Root|Size|Time)|Locate|RefreshShellIcons)}(?=\\s|$)",
+      "match": "(?i)\\$\\{(BannerTrimPath|DirState|DriveSpace|Get(BaseName|Drives|ExeName|ExePath|FileAttributes|FileExt|FileName|FileVersion|OptionsS??|Parameters|Parent|Root|Size|Time)|Locate|RefreshShellIcons)}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "^\\s*(?i)\\$\\{(And(If(Not)?|Unless)|Break|Case([2-5]|Else)?|Continue|Default|Do(Until|While)?|Else(If(Not)?|Unless)?|End(If|Select|Switch)|Exit(Do|For|While)|For(Each)?|If(Cmd|Not(Then)?|Then)?|Loop(Until|While)?|Next|Or(If(Not)?|Unless)|Select|Switch|Unless|While)}(?=\\s|$)",
+      "match": "(?i)\\$\\{(And(If(Not)?|Unless)|Break|Case([2-5]|Else)?|Continue|Default|Do(Until|While)?|Else(If(Not)?|Unless)?|End(If|Select|Switch)|Exit(Do|For|While)|For(Each)?|If(Cmd|Not(Then)?|Then)?|Loop(Until|While)?|Next|Or(If(Not)?|Unless)|Select|Switch|Unless|While)}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "^\\s*(?i)\\$\\{(Memento(Section(Done|End|Restore|Save)?|UnselectedSection))}(?=\\s|$)",
+      "match": "(?i)\\$\\{(Memento(Section(Done|End|Restore|Save)?|UnselectedSection))}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "^\\s*(?i)\\$\\{(Config(ReadS??|WriteS??)|File(Join|ReadFromEnd|Recode)|Line(Find|Read|Sum)|Text(CompareS??)|TrimNewLines)}(?=\\s|$)",
+      "match": "(?i)\\$\\{(Config(ReadS??|WriteS??)|File(Join|ReadFromEnd|Recode)|Line(Find|Read|Sum)|Text(CompareS??)|TrimNewLines)}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "^\\s*(?i)\\$\\{((At(Least|Most)|Is)(ServicePack|Win(7|8\\.1|8|10|11|95|98|20(00|03|08(R2)?|12(R2)?)|ME|NT4|Vista|XP))|Is(NT|Server))}(?=\\s|$)",
+      "match": "(?i)\\$\\{((At(Least|Most)|Is)(ServicePack|Win(7|8\\.1|8|10|11|95|98|20(00|03|08(R2)?|12(R2)?)|ME|NT4|Vista|XP))|Is(NT|Server))}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "^\\s*(?i)\\$\\{(StrFilterS?|Version(Co(?:mpare|nvert))|Word(AddS?|Find(([23])X)?S?|InsertS?|ReplaceS?))}(?=\\s|$)",
+      "match": "(?i)\\$\\{(StrFilterS?|Version(Co(?:mpare|nvert))|Word(AddS?|Find(([23])X)?S?|InsertS?|ReplaceS?))}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "^\\s*(?i)\\$\\{(((?:Dis|En)able)X64FSRedirection|RunningX64)}(?=\\s|$)",
+      "match": "(?i)\\$\\{(((?:Dis|En)able)X64FSRedirection|RunningX64)}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {

--- a/packages/tm-grammars/grammars/nsis.json
+++ b/packages/tm-grammars/grammars/nsis.json
@@ -1,0 +1,252 @@
+{
+  "fileTypes": [
+    "nsi",
+    "nsh",
+    "bnsi",
+    "bnsh",
+    "nsdinc"
+  ],
+  "displayName": "NSIS",
+  "name": "nsis",
+  "patterns": [
+    {
+      "match": "^\\s*(?i)(Abort|AddBrandingImage|AddSize|AllowRootDirInstall|AllowSkipFiles|AutoCloseWindow|BGFont|BGGradient|BrandingText|BringToFront|Call|CallInstDLL|Caption|ChangeUI|CheckBitmap|ClearErrors|CompletedText|ComponentText|CopyFiles|CPU|CRCCheck|CreateDirectory|CreateFont|CreateShortCut|Delete|DeleteINISec|DeleteINIStr|DeleteRegKey|DeleteRegValue|DetailPrint|DetailsButtonText|DirText|DirVar|DirVerify|EnableWindow|EnumRegKey|EnumRegValue|Exch|Exec|ExecShell|ExecShellWait|ExecWait|ExpandEnvStrings|File|FileBufSize|FileClose|FileErrorText|FileOpen|FileRead|FileReadByte|FileReadUTF16LE|FileReadWord|FileWriteUTF16LE|FileSeek|FileWrite|FileWriteByte|FileWriteWord|FindClose|FindFirst|FindNext|FindWindow|FlushINI|Function(End)?|GetCurInstType|GetCurrentAddress|GetDlgItem|GetDLLVersion|GetDLLVersionLocal|GetErrorLevel|GetFileTime|GetFileTimeLocal|GetFullPathName|GetFunctionAddress|GetInstDirError|GetKnownFolderPath|GetLabelAddress|GetRegView|GetShellVarContext|GetTempFileName|GetWinVer|Goto|HideWindow|Icon|IfAbort|IfAltRegView|IfErrors|IfFileExists|IfRebootFlag|IfRtlLanguage|IfShellVarContextAll|IfSilent|InitPluginsDir|InstallButtonText|InstallColors|InstallDir|InstallDirRegKey|InstProgressFlags|InstType|InstTypeGetText|InstTypeSetText|Int64CmpU??|Int64Fmt|IntCmpU??|IntFmt|IntOp|IntPtrCmpU??|IntPtrOp|IsWindow|LangString|LicenseBkColor|LicenseData|LicenseForceSelection|LicenseLangString|LicenseText|LoadAndSetImage|LoadLanguageFile|LockWindow|LogSet|LogText|ManifestAppendCustomString|ManifestDisableWindowFiltering|ManifestDPIAware|ManifestGdiScaling|ManifestLongPathAware|ManifestMaxVersionTested|ManifestSupportedOS|MessageBox|MiscButtonText|Name|Nop|OutFile|Page|PageCallbacks|PageEx(End)?|PEAddResource|PEDllCharacteristics|PERemoveResource|PESubsysVer|Pop|Push|Quit|ReadEnvStr|ReadINIStr|ReadMemory|ReadRegDWORD|ReadRegStr|Reboot|RegDLL|Rename|RequestExecutionLevel|ReserveFile|Return|RMDir|SearchPath|Section(End)?|SectionGroup(End)?|SectionGetFlags|SectionGetInstTypes|SectionGetSize|SectionGetText|SectionIn|SectionSetFlags|SectionSetInstTypes|SectionSetSize|SectionSetText|SendMessage|SetAutoClose|SetBrandingImage|SetCompress|SetCompressionLevel|SetCompressor|SetCompressorDictSize|SetCtlColors|SetCurInstType|SetDatablockOptimize|SetDateSave|SetDetailsPrint|SetDetailsView|SetErrorLevel|SetErrors|SetFileAttributes|SetFont|SetOutPath|SetOverwrite|SetRebootFlag|SetRegView|SetShellVarContext|SetSilent|ShowInstDetails|ShowUninstDetails|ShowWindow|SilentInstall|SilentUnInstall|Sleep|SpaceTexts|StrCmpS??|StrCpy|StrLen|SubCaption|Target|Unicode|UninstallButtonText|UninstallCaption|UninstallIcon|UninstallSubCaption|UninstallText|UninstPage|UnRegDLL|UnsafeStrCpy|Var|VIAddVersionKey|VIFileVersion|VIProductVersion|WindowIcon|WriteINIStr|WriteRegBin|WriteRegDWORD|WriteRegExpandStr|WriteRegMultiStr|WriteRegNone|WriteRegStr|WriteUninstaller|XPStyle)\\b",
+      "name": "keyword.nsis"
+    },
+    {
+      "match": "^\\s*(?i)(CompareDLLVersions|CompareFileTimes|DirShow|DisabledBitmap|EnabledBitmap|GetFullDLLPath|GetParent|GetWinampInstPath|LangStringUP|PackEXEHeader|SectionDivider|SetPluginUnload|SubSection(End)?|UninstallExeName)\\b",
+      "name": "invalid.deprecated.nsis"
+    },
+    {
+      "match": "^\\s*(?i)!(addincludedir|addplugindir|appendfile|assert|cd|define|delfile|echo|error|execute|finalize|getdllversion|gettlbversion|include|insertmacro|macro|macroend|makensis|packhdr|pragma|searchparse|searchreplace|system|tempfile|undef|uninstfinalize|verbose|warning)\\b",
+      "name": "keyword.other.nsis"
+    },
+    {
+      "match": "^\\s*(?i)!(ifdef|ifndef|if|ifmacrodef|ifmacrondef|else|endif)\\b",
+      "name": "keyword.control.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\w+::\\w+",
+      "name": "support.class.nsis"
+    },
+    {
+      "match": "[!<>]?=|<>|[<>]",
+      "name": "keyword.operator.comparison.nsis"
+    },
+    {
+      "match": "\\b(?i)(ARCHIVE|FILE_ATTRIBUTE_ARCHIVE|FILE_ATTRIBUTE_HIDDEN|FILE_ATTRIBUTE_NORMAL|FILE_ATTRIBUTE_OFFLINE|FILE_ATTRIBUTE_READONLY|FILE_ATTRIBUTE_SYSTEM|FILE_ATTRIBUTE_TEMPORARY|HIDDEN|HKCC|HKCR(32|64)?|HKCU(32|64)?|HKDD|HKEY_CLASSES_ROOT|HKEY_CURRENT_CONFIG|HKEY_CURRENT_USER|HKEY_DYN_DATA|HKEY_LOCAL_MACHINE|HKEY_PERFORMANCE_DATA|HKEY_USERS|HKLM(32|64)?|HKPD|HKU|IDABORT|IDCANCEL|IDD_DIR|IDD_INST|IDD_INSTFILES|IDD_LICENSE|IDD_SELCOM|IDD_UNINST|IDD_VERIFY|IDIGNORE|IDNO|IDOK|IDRETRY|IDYES|MB_ABORTRETRYIGNORE|MB_DEFBUTTON1|MB_DEFBUTTON2|MB_DEFBUTTON3|MB_DEFBUTTON4|MB_ICONEXCLAMATION|MB_ICONINFORMATION|MB_ICONQUESTION|MB_ICONSTOP|MB_OK|MB_OKCANCEL|MB_RETRYCANCEL|MB_RIGHT|MB_RTLREADING|MB_SETFOREGROUND|MB_TOPMOST|MB_USERICON|MB_YESNO|MB_YESNOCANCEL|NORMAL|OFFLINE|READONLY|SHCTX|SHELL_CONTEXT|SW_HIDE|SW_SHOWDEFAULT|SW_SHOWMAXIMIZED|SW_SHOWMINIMIZED|SW_SHOWNORMAL|SYSTEM|TEMPORARY)\\b",
+      "name": "entity.other.attribute-name.nsis"
+    },
+    {
+      "match": "\\b(?i)(true|on)\\b",
+      "name": "constant.language.boolean.true.nsis"
+    },
+    {
+      "match": "\\b(?i)(false|off)\\b",
+      "name": "constant.language.boolean.false.nsis"
+    },
+    {
+      "match": "\\b(?i)((un\\.)?components|(un\\.)?custom|(un\\.)?directory|(un\\.)?instfiles|(un\\.)?license|uninstConfirm|admin|all|amd64-unicode|auto|both|bottom|bzip2|current|force|hide|highest|ifdiff|ifnewer|lastused|leave|left|listonly|lzma|nevershow|none|normal|notset|right|show|silent|silentlog|textonly|top|try|user|Win10|Win7|Win8|WinVista|x86-(ansi|unicode)|zlib)\\b",
+      "name": "entity.other.attribute-name.nsis"
+    },
+    {
+      "match": "\\s+/(?i)(BRANDING|CENTER|COMPONENTSONLYONCUSTOM|CUSTOMSTRING=|ENABLECANCEL|EXERESOURCE|FILESONLY|FINAL|GLOBAL|IMGID=|ITALIC|LANG=|NOCUSTOM|NONFATAL|OVERWRITE|REBOOTOK|REPLACE|RESIZETOFIT|SHORT|SILENT|SOLID|STRIKE|STRINGID|TRIM|UNDERLINE|a|date|e|file|gray|ifempty|ifndef|ignorecase|noerrors|nonfatal|o|oname=|r|redef|utcdate|windows|x)\\b",
+      "name": "constant.language.slash-option.nsis"
+    },
+    {
+      "match": "\\b((0([Xx])\\h+)|([0-9]+(\\.[0-9]+)?))\\b",
+      "name": "constant.numeric.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\$\\{(BannerTrimPath|DirState|DriveSpace|Get(BaseName|Drives|ExeName|ExePath|FileAttributes|FileExt|FileName|FileVersion|OptionsS??|Parameters|Parent|Root|Size|Time)|Locate|RefreshShellIcons)}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\$\\{(And(If(Not)?|Unless)|Break|Case([2-5]|Else)?|Continue|Default|Do(Until|While)?|Else(If(Not)?|Unless)?|End(If|Select|Switch)|Exit(Do|For|While)|For(Each)?|If(Cmd|Not(Then)?|Then)?|Loop(Until|While)?|Next|Or(If(Not)?|Unless)|Select|Switch|Unless|While)}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\$\\{(Memento(Section(Done|End|Restore|Save)?|UnselectedSection))}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\$\\{(Config(ReadS??|WriteS??)|File(Join|ReadFromEnd|Recode)|Line(Find|Read|Sum)|Text(CompareS??)|TrimNewLines)}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\$\\{((At(Least|Most)|Is)(ServicePack|Win(7|8\\.1|8|10|11|95|98|20(00|03|08(R2)?|12(R2)?)|ME|NT4|Vista|XP))|Is(NT|Server))}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\$\\{(StrFilterS?|Version(Co(?:mpare|nvert))|Word(AddS?|Find(([23])X)?S?|InsertS?|ReplaceS?))}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\$\\{(((?:Dis|En)able)X64FSRedirection|RunningX64)}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "\\$\\{[-!.:^\\w]+}",
+      "name": "constant.other.nsis"
+    },
+    {
+      "match": "\\$\\([-!.:^\\w]+\\)",
+      "name": "constant.other.nsis"
+    },
+    {
+      "match": "(?i)\\$(\\{__DATE__}|\\{__FILE__}|\\{__FILEDIR__}|\\{__LINE__}|\\{__TIME__}|\\{__TIMESTAMP__}|ADMINTOOLS|APPDATA|CDBURN_AREA|CMDLINE|COMMONFILES|COOKIES|DESKTOP|DOCUMENTS|EXEDIR|EXEFILE|EXEPATH|FAVORITES|FONTS|HISTORY|HWNDPARENT|INSTDIR|INTERNET_CACHE|LANGUAGE|LOCALAPPDATA|MUSIC|NETHOOD|NSIS_MAX_STRLEN|NSIS_VERSION|NSISDIR|OUTDIR|PICTURES|PLUGINSDIR|PRINTHOOD|PROFILE|PROGRAMFILES(32|64)?|QUICKLAUNCH|RECENT|RESOURCES_LOCALIZED|RESOURCES|SENDTO|SMPROGRAMS|SMSTARTUP|STARTMENU|SYSDIR|TEMP|TEMPLATES|VIDEOS|WINDIR)\\b",
+      "name": "variable.language.nsis"
+    },
+    {
+      "match": "\\$\\w[.\\w]*",
+      "name": "variable.other.nsis"
+    },
+    {
+      "match": "\\\\(?=\\n)",
+      "name": "constant.character.escape.line-continuation.nsis"
+    },
+    {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.nsis"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.nsis"
+        }
+      },
+      "name": "string.quoted.double.nsis",
+      "patterns": [
+        {
+          "match": "\\${2}\\w*",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\$\\\\.",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\$\\{[-!.:^\\w]+}",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "\\$\\([-!.:^\\w]+\\)",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "(?i)\\$(\\{__DATE__}|\\{__FILE__}|\\{__FILEDIR__}|\\{__LINE__}|\\{__TIME__}|\\{__TIMESTAMP__}|ADMINTOOLS|APPDATA|CDBURN_AREA|CMDLINE|COMMONFILES|COOKIES|DESKTOP|DOCUMENTS|EXEDIR|EXEFILE|EXEPATH|FAVORITES|FONTS|HISTORY|HWNDPARENT|INSTDIR|INTERNET_CACHE|LANGUAGE|LOCALAPPDATA|MUSIC|NETHOOD|NSIS_MAX_STRLEN|NSIS_VERSION|NSISDIR|OUTDIR|PICTURES|PLUGINSDIR|PRINTHOOD|PROFILE|PROGRAMFILES(32|64)?|QUICKLAUNCH|RECENT|RESOURCES_LOCALIZED|RESOURCES|SENDTO|SMPROGRAMS|SMSTARTUP|STARTMENU|SYSDIR|TEMP|TEMPLATES|VIDEOS|WINDIR)\\b",
+          "name": "variable.language.nsis"
+        },
+        {
+          "match": "\\$\\w[.\\w]*",
+          "name": "variable.other.nsis"
+        }
+      ]
+    },
+    {
+      "begin": "'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.nsis"
+        }
+      },
+      "end": "'",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.nsis"
+        }
+      },
+      "name": "string.quoted.single.nsis",
+      "patterns": [
+        {
+          "match": "\\${2}\\w*",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\$\\\\.",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\$\\{[-!.:^\\w]+}",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "\\$\\([-!.:^\\w]+\\)",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "(?i)\\$(\\{__DATE__}|\\{__FILE__}|\\{__FILEDIR__}|\\{__LINE__}|\\{__TIME__}|\\{__TIMESTAMP__}|ADMINTOOLS|APPDATA|CDBURN_AREA|CMDLINE|COMMONFILES|COOKIES|DESKTOP|DOCUMENTS|EXEDIR|EXEFILE|EXEPATH|FAVORITES|FONTS|HISTORY|HWNDPARENT|INSTDIR|INTERNET_CACHE|LANGUAGE|LOCALAPPDATA|MUSIC|NETHOOD|NSIS_MAX_STRLEN|NSIS_VERSION|NSISDIR|OUTDIR|PICTURES|PLUGINSDIR|PRINTHOOD|PROFILE|PROGRAMFILES(32|64)?|QUICKLAUNCH|RECENT|RESOURCES_LOCALIZED|RESOURCES|SENDTO|SMPROGRAMS|SMSTARTUP|STARTMENU|SYSDIR|TEMP|TEMPLATES|VIDEOS|WINDIR)\\b",
+          "name": "variable.language.nsis"
+        },
+        {
+          "match": "\\$\\w[.\\w]*",
+          "name": "variable.other.nsis"
+        }
+      ]
+    },
+    {
+      "begin": "`",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.nsis"
+        }
+      },
+      "end": "`",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.nsis"
+        }
+      },
+      "name": "string.quoted.back.nsis",
+      "patterns": [
+        {
+          "match": "\\${2}\\w*",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\$\\\\.",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\$\\{[-!.:^\\w]+}",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "\\$\\([-!.:^\\w]+\\)",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "(?i)\\$(\\{__DATE__}|\\{__FILE__}|\\{__FILEDIR__}|\\{__LINE__}|\\{__TIME__}|\\{__TIMESTAMP__}|ADMINTOOLS|APPDATA|CDBURN_AREA|CMDLINE|COMMONFILES|COOKIES|DESKTOP|DOCUMENTS|EXEDIR|EXEFILE|EXEPATH|FAVORITES|FONTS|HISTORY|HWNDPARENT|INSTDIR|INTERNET_CACHE|LANGUAGE|LOCALAPPDATA|MUSIC|NETHOOD|NSIS_MAX_STRLEN|NSIS_VERSION|NSISDIR|OUTDIR|PICTURES|PLUGINSDIR|PRINTHOOD|PROFILE|PROGRAMFILES(32|64)?|QUICKLAUNCH|RECENT|RESOURCES_LOCALIZED|RESOURCES|SENDTO|SMPROGRAMS|SMSTARTUP|STARTMENU|SYSDIR|TEMP|TEMPLATES|VIDEOS|WINDIR)\\b",
+          "name": "variable.language.nsis"
+        },
+        {
+          "match": "\\$\\w[.\\w]*",
+          "name": "variable.other.nsis"
+        }
+      ]
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.comment.nsis"
+        }
+      },
+      "match": "([#;]).*$\\n?",
+      "name": "comment.line.nsis"
+    },
+    {
+      "begin": "/\\*",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.nsis"
+        }
+      },
+      "end": "\\*/",
+      "name": "comment.block.nsis"
+    }
+  ],
+  "scopeName": "source.nsis"
+}

--- a/packages/tm-grammars/index.js
+++ b/packages/tm-grammars/index.js
@@ -3002,6 +3002,28 @@ export const grammars = [
     sourceApi: 'https://api.github.com/repos/nix-community/vscode-nix-ide/contents/dist/nix.tmLanguage.json?ref=effbf3494a43250a537834805b305793994b9ca8',
   },
   {
+    byteSize: 13470,
+    categories: [
+      'scripting',
+    ],
+    displayName: 'NSIS',
+    funding: [
+      {
+        name: 'buymeacoffee.com',
+        url: 'https://www.buymeacoffee.com/idleberg',
+      },
+    ],
+    hash: '8M0-VtbIgXNY-wba1PhWmgaDyMbFwRcXfvwUde4kSOI',
+    lastUpdate: '2026-03-19T23:22:55+01:00',
+    license: 'Apache-2.0',
+    licenseUrl: 'https://github.com/idleberg/vscode-nsis/blob/main/syntaxes/nsis-license.txt',
+    name: 'nsis',
+    scopeName: 'source.nsis',
+    sha: '43101f1f8ec1e4097082637b19b685d52db2f7e2',
+    source: 'https://github.com/idleberg/vscode-nsis/blob/43101f1f8ec1e4097082637b19b685d52db2f7e2/syntaxes/nsis.tmLanguage',
+    sourceApi: 'https://api.github.com/repos/idleberg/vscode-nsis/contents/syntaxes/nsis.tmLanguage?ref=43101f1f8ec1e4097082637b19b685d52db2f7e2',
+  },
+  {
     aliases: [
       'nu',
     ],

--- a/packages/tm-grammars/index.js
+++ b/packages/tm-grammars/index.js
@@ -3002,7 +3002,7 @@ export const grammars = [
     sourceApi: 'https://api.github.com/repos/nix-community/vscode-nix-ide/contents/dist/nix.tmLanguage.json?ref=effbf3494a43250a537834805b305793994b9ca8',
   },
   {
-    byteSize: 13470,
+    byteSize: 15439,
     categories: [
       'scripting',
     ],
@@ -3013,15 +3013,15 @@ export const grammars = [
         url: 'https://www.buymeacoffee.com/idleberg',
       },
     ],
-    hash: '8M0-VtbIgXNY-wba1PhWmgaDyMbFwRcXfvwUde4kSOI',
-    lastUpdate: '2026-03-19T23:22:55+01:00',
+    hash: 'gjxFsHDuKgRqR7hZxmvQ8dRetk4KQf-Qu-TthfbDQ-A',
+    lastUpdate: '2026-07-15T21:41:45+02:00',
     license: 'Apache-2.0',
     licenseUrl: 'https://github.com/idleberg/vscode-nsis/blob/main/syntaxes/nsis-license.txt',
     name: 'nsis',
     scopeName: 'source.nsis',
-    sha: '43101f1f8ec1e4097082637b19b685d52db2f7e2',
-    source: 'https://github.com/idleberg/vscode-nsis/blob/43101f1f8ec1e4097082637b19b685d52db2f7e2/syntaxes/nsis.tmLanguage',
-    sourceApi: 'https://api.github.com/repos/idleberg/vscode-nsis/contents/syntaxes/nsis.tmLanguage?ref=43101f1f8ec1e4097082637b19b685d52db2f7e2',
+    sha: 'a87d11e5b7c815a4c8321ec4b65746aa892f3e93',
+    source: 'https://github.com/idleberg/vscode-nsis/blob/a87d11e5b7c815a4c8321ec4b65746aa892f3e93/syntaxes/nsis.tmLanguage',
+    sourceApi: 'https://api.github.com/repos/idleberg/vscode-nsis/contents/syntaxes/nsis.tmLanguage?ref=a87d11e5b7c815a4c8321ec4b65746aa892f3e93',
   },
   {
     aliases: [

--- a/packages/tm-grammars/raw/nsis.json
+++ b/packages/tm-grammars/raw/nsis.json
@@ -9,6 +9,96 @@
   "name": "NSIS",
   "patterns": [
     {
+      "captures": {
+        "1": {
+          "name": "keyword.nsis"
+        },
+        "2": {
+          "name": "entity.name.function.nsis"
+        }
+      },
+      "comment": "Function definition",
+      "match": "^\\s*(?i)(Function)\\s+(\\.?\\w+)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.other.nsis"
+        },
+        "2": {
+          "name": "entity.name.function.macro.nsis"
+        }
+      },
+      "comment": "Macro definition",
+      "match": "^\\s*(?i)(\\!macro)\\s+(\\w+)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.other.nsis"
+        },
+        "2": {
+          "name": "entity.name.constant.define.nsis"
+        }
+      },
+      "comment": "Define definition",
+      "match": "^\\s*(?i)(\\!define)\\s+(?:/\\w+\\s+)*(\\w+)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.nsis"
+        },
+        "2": {
+          "name": "entity.name.variable.nsis"
+        }
+      },
+      "comment": "Variable declaration",
+      "match": "^\\s*(?i)(Var)\\s+(?:/GLOBAL\\s+)?\"?(\\w+)\"?"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.nsis"
+        },
+        "2": {
+          "name": "string.quoted.double.nsis"
+        },
+        "3": {
+          "name": "string.quoted.single.nsis"
+        },
+        "4": {
+          "name": "string.quoted.back.nsis"
+        },
+        "5": {
+          "name": "entity.name.section.nsis"
+        }
+      },
+      "comment": "Section/SectionGroup with explicit ID",
+      "match": "^\\s*(?i)(Section(?:Group)?)\\s+(?:/[oe]\\s+)?(?:(\"[^\"]*\")|('[^']*')|(`[^`]*`))\\s+(\\w+)"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.nsis"
+        },
+        "2": {
+          "name": "entity.name.section.nsis string.quoted.double.nsis"
+        },
+        "3": {
+          "name": "entity.name.section.nsis string.quoted.single.nsis"
+        },
+        "4": {
+          "name": "entity.name.section.nsis string.quoted.back.nsis"
+        },
+        "5": {
+          "name": "entity.name.section.nsis"
+        }
+      },
+      "comment": "Section/SectionGroup with name only",
+      "match": "^\\s*(?i)(Section(?:Group)?)\\s+(?:/[oe]\\s+)?(?:\"([^\"]+)\"|'([^']+)'|`([^`]+)`|([\\w.-]+))\\s*$"
+    },
+    {
       "match": "^\\s*(?i)(Abort|AddBrandingImage|AddSize|AllowRootDirInstall|AllowSkipFiles|AutoCloseWindow|BGFont|BGGradient|BrandingText|BringToFront|Call|CallInstDLL|Caption|ChangeUI|CheckBitmap|ClearErrors|CompletedText|ComponentText|CopyFiles|CPU|CRCCheck|CreateDirectory|CreateFont|CreateShortCut|Delete|DeleteINISec|DeleteINIStr|DeleteRegKey|DeleteRegValue|DetailPrint|DetailsButtonText|DirText|DirVar|DirVerify|EnableWindow|EnumRegKey|EnumRegValue|Exch|Exec|ExecShell|ExecShellWait|ExecWait|ExpandEnvStrings|File|FileBufSize|FileClose|FileErrorText|FileOpen|FileRead|FileReadByte|FileReadUTF16LE|FileReadWord|FileWriteUTF16LE|FileSeek|FileWrite|FileWriteByte|FileWriteWord|FindClose|FindFirst|FindNext|FindWindow|FlushINI|Function(End)?|GetCurInstType|GetCurrentAddress|GetDlgItem|GetDLLVersion|GetDLLVersionLocal|GetErrorLevel|GetFileTime|GetFileTimeLocal|GetFullPathName|GetFunctionAddress|GetInstDirError|GetKnownFolderPath|GetLabelAddress|GetRegView|GetShellVarContext|GetTempFileName|GetWinVer|Goto|HideWindow|Icon|IfAbort|IfAltRegView|IfErrors|IfFileExists|IfRebootFlag|IfRtlLanguage|IfShellVarContextAll|IfSilent|InitPluginsDir|InstallButtonText|InstallColors|InstallDir|InstallDirRegKey|InstProgressFlags|InstType|InstTypeGetText|InstTypeSetText|Int64Cmp|Int64CmpU|Int64Fmt|IntCmp|IntCmpU|IntFmt|IntOp|IntPtrCmp|IntPtrCmpU|IntPtrOp|IsWindow|LangString|LicenseBkColor|LicenseData|LicenseForceSelection|LicenseLangString|LicenseText|LoadAndSetImage|LoadLanguageFile|LockWindow|LogSet|LogText|ManifestAppendCustomString|ManifestDisableWindowFiltering|ManifestDPIAware|ManifestGdiScaling|ManifestLongPathAware|ManifestMaxVersionTested|ManifestSupportedOS|MessageBox|MiscButtonText|Name|Nop|OutFile|Page|PageCallbacks|PageEx(End)?|PEAddResource|PEDllCharacteristics|PERemoveResource|PESubsysVer|Pop|Push|Quit|ReadEnvStr|ReadINIStr|ReadMemory|ReadRegDWORD|ReadRegStr|Reboot|RegDLL|Rename|RequestExecutionLevel|ReserveFile|Return|RMDir|SearchPath|Section(End)?|SectionGroup(End)?|SectionGetFlags|SectionGetInstTypes|SectionGetSize|SectionGetText|SectionIn|SectionSetFlags|SectionSetInstTypes|SectionSetSize|SectionSetText|SendMessage|SetAutoClose|SetBrandingImage|SetCompress|SetCompressionLevel|SetCompressor|SetCompressorDictSize|SetCtlColors|SetCurInstType|SetDatablockOptimize|SetDateSave|SetDetailsPrint|SetDetailsView|SetErrorLevel|SetErrors|SetFileAttributes|SetFont|SetOutPath|SetOverwrite|SetRebootFlag|SetRegView|SetShellVarContext|SetSilent|ShowInstDetails|ShowUninstDetails|ShowWindow|SilentInstall|SilentUnInstall|Sleep|SpaceTexts|StrCmp|StrCmpS|StrCpy|StrLen|SubCaption|Target|Unicode|UninstallButtonText|UninstallCaption|UninstallIcon|UninstallSubCaption|UninstallText|UninstPage|UnRegDLL|UnsafeStrCpy|Var|VIAddVersionKey|VIFileVersion|VIProductVersion|WindowIcon|WriteINIStr|WriteRegBin|WriteRegDWORD|WriteRegExpandStr|WriteRegMultiStr|WriteRegNone|WriteRegStr|WriteUninstaller|XPStyle)\\b",
       "name": "keyword.nsis"
     },
@@ -57,31 +147,31 @@
       "name": "constant.numeric.nsis"
     },
     {
-      "match": "(?:^\\s*)(?i)\\${(BannerTrimPath|DirState|DriveSpace|Get(BaseName|Drives|ExeName|ExePath|FileAttributes|FileExt|FileName|FileVersion|Options|OptionsS|Parameters|Parent|Root|Size|Time)|Locate|RefreshShellIcons)}(?=\\s|$)",
+      "match": "(?i)\\${(BannerTrimPath|DirState|DriveSpace|Get(BaseName|Drives|ExeName|ExePath|FileAttributes|FileExt|FileName|FileVersion|Options|OptionsS|Parameters|Parent|Root|Size|Time)|Locate|RefreshShellIcons)}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "(?:^\\s*)(?i)\\${(And(If(Not)?|Unless)|Break|Case(2|3|4|5|Else)?|Continue|Default|Do(Until|While)?|Else(If(Not)?|Unless)?|End(If|Select|Switch)|Exit(Do|For|While)|For(Each)?|If(Cmd|Not(Then)?|Then)?|Loop(Until|While)?|Next|Or(If(Not)?|Unless)|Select|Switch|Unless|While)}(?=\\s|$)",
+      "match": "(?i)\\${(And(If(Not)?|Unless)|Break|Case(2|3|4|5|Else)?|Continue|Default|Do(Until|While)?|Else(If(Not)?|Unless)?|End(If|Select|Switch)|Exit(Do|For|While)|For(Each)?|If(Cmd|Not(Then)?|Then)?|Loop(Until|While)?|Next|Or(If(Not)?|Unless)|Select|Switch|Unless|While)}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "(?:^\\s*)(?i)\\${(Memento(Section(Done|End|Restore|Save)?|UnselectedSection))}(?=\\s|$)",
+      "match": "(?i)\\${(Memento(Section(Done|End|Restore|Save)?|UnselectedSection))}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "(?:^\\s*)(?i)\\${(Config(Read|ReadS|Write|WriteS)|File(Join|ReadFromEnd|Recode)|Line(Find|Read|Sum)|Text(Compare|CompareS)|TrimNewLines)}(?=\\s|$)",
+      "match": "(?i)\\${(Config(Read|ReadS|Write|WriteS)|File(Join|ReadFromEnd|Recode)|Line(Find|Read|Sum)|Text(Compare|CompareS)|TrimNewLines)}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "(?:^\\s*)(?i)\\${((At(Least|Most)|Is)(ServicePack|Win(7|8\\.1|8|10|11|95|98|20(00|03|08(R2)?|12(R2)?)|ME|NT4|Vista|XP))|Is(NT|Server))}(?=\\s|$)",
+      "match": "(?i)\\${((At(Least|Most)|Is)(ServicePack|Win(7|8\\.1|8|10|11|95|98|20(00|03|08(R2)?|12(R2)?)|ME|NT4|Vista|XP))|Is(NT|Server))}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "(?:^\\s*)(?i)\\${(StrFilterS?|Version(Compare|Convert)|Word(AddS?|Find((2|3)X)?S?|InsertS?|ReplaceS?))}(?=\\s|$)",
+      "match": "(?i)\\${(StrFilterS?|Version(Compare|Convert)|Word(AddS?|Find((2|3)X)?S?|InsertS?|ReplaceS?))}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {
-      "match": "(?:^\\s*)(?i)\\${((Disable|Enable)X64FSRedirection|RunningX64)}(?=\\s|$)",
+      "match": "(?i)\\${((Disable|Enable)X64FSRedirection|RunningX64)}(?=\\s|$)",
       "name": "constant.language.nsis"
     },
     {

--- a/packages/tm-grammars/raw/nsis.json
+++ b/packages/tm-grammars/raw/nsis.json
@@ -1,0 +1,252 @@
+{
+  "fileTypes": [
+    "nsi",
+    "nsh",
+    "bnsi",
+    "bnsh",
+    "nsdinc"
+  ],
+  "name": "NSIS",
+  "patterns": [
+    {
+      "match": "^\\s*(?i)(Abort|AddBrandingImage|AddSize|AllowRootDirInstall|AllowSkipFiles|AutoCloseWindow|BGFont|BGGradient|BrandingText|BringToFront|Call|CallInstDLL|Caption|ChangeUI|CheckBitmap|ClearErrors|CompletedText|ComponentText|CopyFiles|CPU|CRCCheck|CreateDirectory|CreateFont|CreateShortCut|Delete|DeleteINISec|DeleteINIStr|DeleteRegKey|DeleteRegValue|DetailPrint|DetailsButtonText|DirText|DirVar|DirVerify|EnableWindow|EnumRegKey|EnumRegValue|Exch|Exec|ExecShell|ExecShellWait|ExecWait|ExpandEnvStrings|File|FileBufSize|FileClose|FileErrorText|FileOpen|FileRead|FileReadByte|FileReadUTF16LE|FileReadWord|FileWriteUTF16LE|FileSeek|FileWrite|FileWriteByte|FileWriteWord|FindClose|FindFirst|FindNext|FindWindow|FlushINI|Function(End)?|GetCurInstType|GetCurrentAddress|GetDlgItem|GetDLLVersion|GetDLLVersionLocal|GetErrorLevel|GetFileTime|GetFileTimeLocal|GetFullPathName|GetFunctionAddress|GetInstDirError|GetKnownFolderPath|GetLabelAddress|GetRegView|GetShellVarContext|GetTempFileName|GetWinVer|Goto|HideWindow|Icon|IfAbort|IfAltRegView|IfErrors|IfFileExists|IfRebootFlag|IfRtlLanguage|IfShellVarContextAll|IfSilent|InitPluginsDir|InstallButtonText|InstallColors|InstallDir|InstallDirRegKey|InstProgressFlags|InstType|InstTypeGetText|InstTypeSetText|Int64Cmp|Int64CmpU|Int64Fmt|IntCmp|IntCmpU|IntFmt|IntOp|IntPtrCmp|IntPtrCmpU|IntPtrOp|IsWindow|LangString|LicenseBkColor|LicenseData|LicenseForceSelection|LicenseLangString|LicenseText|LoadAndSetImage|LoadLanguageFile|LockWindow|LogSet|LogText|ManifestAppendCustomString|ManifestDisableWindowFiltering|ManifestDPIAware|ManifestGdiScaling|ManifestLongPathAware|ManifestMaxVersionTested|ManifestSupportedOS|MessageBox|MiscButtonText|Name|Nop|OutFile|Page|PageCallbacks|PageEx(End)?|PEAddResource|PEDllCharacteristics|PERemoveResource|PESubsysVer|Pop|Push|Quit|ReadEnvStr|ReadINIStr|ReadMemory|ReadRegDWORD|ReadRegStr|Reboot|RegDLL|Rename|RequestExecutionLevel|ReserveFile|Return|RMDir|SearchPath|Section(End)?|SectionGroup(End)?|SectionGetFlags|SectionGetInstTypes|SectionGetSize|SectionGetText|SectionIn|SectionSetFlags|SectionSetInstTypes|SectionSetSize|SectionSetText|SendMessage|SetAutoClose|SetBrandingImage|SetCompress|SetCompressionLevel|SetCompressor|SetCompressorDictSize|SetCtlColors|SetCurInstType|SetDatablockOptimize|SetDateSave|SetDetailsPrint|SetDetailsView|SetErrorLevel|SetErrors|SetFileAttributes|SetFont|SetOutPath|SetOverwrite|SetRebootFlag|SetRegView|SetShellVarContext|SetSilent|ShowInstDetails|ShowUninstDetails|ShowWindow|SilentInstall|SilentUnInstall|Sleep|SpaceTexts|StrCmp|StrCmpS|StrCpy|StrLen|SubCaption|Target|Unicode|UninstallButtonText|UninstallCaption|UninstallIcon|UninstallSubCaption|UninstallText|UninstPage|UnRegDLL|UnsafeStrCpy|Var|VIAddVersionKey|VIFileVersion|VIProductVersion|WindowIcon|WriteINIStr|WriteRegBin|WriteRegDWORD|WriteRegExpandStr|WriteRegMultiStr|WriteRegNone|WriteRegStr|WriteUninstaller|XPStyle)\\b",
+      "name": "keyword.nsis"
+    },
+    {
+      "match": "^\\s*(?i)(CompareDLLVersions|CompareFileTimes|DirShow|DisabledBitmap|EnabledBitmap|GetFullDLLPath|GetParent|GetWinampInstPath|LangStringUP|PackEXEHeader|SectionDivider|SetPluginUnload|SubSection(End)?|UninstallExeName)\\b",
+      "name": "invalid.deprecated.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\!(addincludedir|addplugindir|appendfile|assert|cd|define|delfile|echo|error|execute|finalize|getdllversion|gettlbversion|include|insertmacro|macro|macroend|makensis|packhdr|pragma|searchparse|searchreplace|system|tempfile|undef|uninstfinalize|verbose|warning)\\b",
+      "name": "keyword.other.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\!(ifdef|ifndef|if|ifmacrodef|ifmacrondef|else|endif)\\b",
+      "name": "keyword.control.nsis"
+    },
+    {
+      "match": "^\\s*(?i)\\w+\\:\\:\\w+",
+      "name": "support.class.nsis"
+    },
+    {
+      "match": "[!<>]?=|<>|<|>",
+      "name": "keyword.operator.comparison.nsis"
+    },
+    {
+      "match": "\\b(?i)(ARCHIVE|FILE_ATTRIBUTE_ARCHIVE|FILE_ATTRIBUTE_HIDDEN|FILE_ATTRIBUTE_NORMAL|FILE_ATTRIBUTE_OFFLINE|FILE_ATTRIBUTE_READONLY|FILE_ATTRIBUTE_SYSTEM|FILE_ATTRIBUTE_TEMPORARY|HIDDEN|HKCC|HKCR(32|64)?|HKCU(32|64)?|HKDD|HKEY_CLASSES_ROOT|HKEY_CURRENT_CONFIG|HKEY_CURRENT_USER|HKEY_DYN_DATA|HKEY_LOCAL_MACHINE|HKEY_PERFORMANCE_DATA|HKEY_USERS|HKLM(32|64)?|HKPD|HKU|IDABORT|IDCANCEL|IDD_DIR|IDD_INST|IDD_INSTFILES|IDD_LICENSE|IDD_SELCOM|IDD_UNINST|IDD_VERIFY|IDIGNORE|IDNO|IDOK|IDRETRY|IDYES|MB_ABORTRETRYIGNORE|MB_DEFBUTTON1|MB_DEFBUTTON2|MB_DEFBUTTON3|MB_DEFBUTTON4|MB_ICONEXCLAMATION|MB_ICONINFORMATION|MB_ICONQUESTION|MB_ICONSTOP|MB_OK|MB_OKCANCEL|MB_RETRYCANCEL|MB_RIGHT|MB_RTLREADING|MB_SETFOREGROUND|MB_TOPMOST|MB_USERICON|MB_YESNO|MB_YESNOCANCEL|NORMAL|OFFLINE|READONLY|SHCTX|SHELL_CONTEXT|SW_HIDE|SW_SHOWDEFAULT|SW_SHOWMAXIMIZED|SW_SHOWMINIMIZED|SW_SHOWNORMAL|SYSTEM|TEMPORARY)\\b",
+      "name": "entity.other.attribute-name.nsis"
+    },
+    {
+      "match": "\\b(?i)(true|on)\\b",
+      "name": "constant.language.boolean.true.nsis"
+    },
+    {
+      "match": "\\b(?i)(false|off)\\b",
+      "name": "constant.language.boolean.false.nsis"
+    },
+    {
+      "match": "\\b(?i)((un\\.)?components|(un\\.)?custom|(un\\.)?directory|(un\\.)?instfiles|(un\\.)?license|uninstConfirm|admin|all|amd64-unicode|auto|both|bottom|bzip2|current|force|hide|highest|ifdiff|ifnewer|lastused|leave|left|listonly|lzma|nevershow|none|normal|notset|right|show|silent|silentlog|textonly|top|try|user|Win10|Win7|Win8|WinVista|x86-(ansi|unicode)|zlib)\\b",
+      "name": "entity.other.attribute-name.nsis"
+    },
+    {
+      "match": "\\s+\\/(?i)(BRANDING|CENTER|COMPONENTSONLYONCUSTOM|CUSTOMSTRING\\=|ENABLECANCEL|EXERESOURCE|FILESONLY|FINAL|GLOBAL|IMGID\\=|ITALIC|LANG\\=|NOCUSTOM|NONFATAL|OVERWRITE|REBOOTOK|REPLACE|RESIZETOFIT|SHORT|SILENT|SOLID|STRIKE|STRINGID|TRIM|UNDERLINE|a|date|e|file|gray|ifempty|ifndef|ignorecase|noerrors|nonfatal|o|oname\\=|r|redef|utcdate|windows|x)\\b",
+      "name": "constant.language.slash-option.nsis"
+    },
+    {
+      "match": "\\b((0(x|X)[0-9a-fA-F]+)|([0-9]+(\\.[0-9]+)?))\\b",
+      "name": "constant.numeric.nsis"
+    },
+    {
+      "match": "(?:^\\s*)(?i)\\${(BannerTrimPath|DirState|DriveSpace|Get(BaseName|Drives|ExeName|ExePath|FileAttributes|FileExt|FileName|FileVersion|Options|OptionsS|Parameters|Parent|Root|Size|Time)|Locate|RefreshShellIcons)}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "(?:^\\s*)(?i)\\${(And(If(Not)?|Unless)|Break|Case(2|3|4|5|Else)?|Continue|Default|Do(Until|While)?|Else(If(Not)?|Unless)?|End(If|Select|Switch)|Exit(Do|For|While)|For(Each)?|If(Cmd|Not(Then)?|Then)?|Loop(Until|While)?|Next|Or(If(Not)?|Unless)|Select|Switch|Unless|While)}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "(?:^\\s*)(?i)\\${(Memento(Section(Done|End|Restore|Save)?|UnselectedSection))}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "(?:^\\s*)(?i)\\${(Config(Read|ReadS|Write|WriteS)|File(Join|ReadFromEnd|Recode)|Line(Find|Read|Sum)|Text(Compare|CompareS)|TrimNewLines)}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "(?:^\\s*)(?i)\\${((At(Least|Most)|Is)(ServicePack|Win(7|8\\.1|8|10|11|95|98|20(00|03|08(R2)?|12(R2)?)|ME|NT4|Vista|XP))|Is(NT|Server))}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "(?:^\\s*)(?i)\\${(StrFilterS?|Version(Compare|Convert)|Word(AddS?|Find((2|3)X)?S?|InsertS?|ReplaceS?))}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "(?:^\\s*)(?i)\\${((Disable|Enable)X64FSRedirection|RunningX64)}(?=\\s|$)",
+      "name": "constant.language.nsis"
+    },
+    {
+      "match": "\\${[\\!\\w\\.:\\^-]+}",
+      "name": "constant.other.nsis"
+    },
+    {
+      "match": "\\$\\([\\!\\w\\.:\\^-]+\\)",
+      "name": "constant.other.nsis"
+    },
+    {
+      "match": "(?i)\\$(\\{__DATE__\\}|\\{__FILE__\\}|\\{__FILEDIR__\\}|\\{__LINE__\\}|\\{__TIME__\\}|\\{__TIMESTAMP__\\}|ADMINTOOLS|APPDATA|CDBURN_AREA|CMDLINE|COMMONFILES|COOKIES|DESKTOP|DOCUMENTS|EXEDIR|EXEFILE|EXEPATH|FAVORITES|FONTS|HISTORY|HWNDPARENT|INSTDIR|INTERNET_CACHE|LANGUAGE|LOCALAPPDATA|MUSIC|NETHOOD|NSIS_MAX_STRLEN|NSIS_VERSION|NSISDIR|OUTDIR|PICTURES|PLUGINSDIR|PRINTHOOD|PROFILE|PROGRAMFILES(32|64)?|QUICKLAUNCH|RECENT|RESOURCES_LOCALIZED|RESOURCES|SENDTO|SMPROGRAMS|SMSTARTUP|STARTMENU|SYSDIR|TEMP|TEMPLATES|VIDEOS|WINDIR)\\b",
+      "name": "variable.language.nsis"
+    },
+    {
+      "match": "\\$\\w[\\w\\.]*",
+      "name": "variable.other.nsis"
+    },
+    {
+      "match": "\\\\(?=\\n)",
+      "name": "constant.character.escape.line-continuation.nsis"
+    },
+    {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.nsis"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.nsis"
+        }
+      },
+      "name": "string.quoted.double.nsis",
+      "patterns": [
+        {
+          "match": "\\${2}\\w*",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\$\\\\.",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\${[\\!\\w\\.:\\^-]+}",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "\\$\\([\\!\\w\\.:\\^-]+\\)",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "(?i)\\$(\\{__DATE__\\}|\\{__FILE__\\}|\\{__FILEDIR__\\}|\\{__LINE__\\}|\\{__TIME__\\}|\\{__TIMESTAMP__\\}|ADMINTOOLS|APPDATA|CDBURN_AREA|CMDLINE|COMMONFILES|COOKIES|DESKTOP|DOCUMENTS|EXEDIR|EXEFILE|EXEPATH|FAVORITES|FONTS|HISTORY|HWNDPARENT|INSTDIR|INTERNET_CACHE|LANGUAGE|LOCALAPPDATA|MUSIC|NETHOOD|NSIS_MAX_STRLEN|NSIS_VERSION|NSISDIR|OUTDIR|PICTURES|PLUGINSDIR|PRINTHOOD|PROFILE|PROGRAMFILES(32|64)?|QUICKLAUNCH|RECENT|RESOURCES_LOCALIZED|RESOURCES|SENDTO|SMPROGRAMS|SMSTARTUP|STARTMENU|SYSDIR|TEMP|TEMPLATES|VIDEOS|WINDIR)\\b",
+          "name": "variable.language.nsis"
+        },
+        {
+          "match": "\\$\\w[\\w\\.]*",
+          "name": "variable.other.nsis"
+        }
+      ]
+    },
+    {
+      "begin": "'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.nsis"
+        }
+      },
+      "end": "'",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.nsis"
+        }
+      },
+      "name": "string.quoted.single.nsis",
+      "patterns": [
+        {
+          "match": "\\${2}\\w*",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\$\\\\.",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\${[\\!\\w\\.:\\^-]+}",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "\\$\\([\\!\\w\\.:\\^-]+\\)",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "(?i)\\$(\\{__DATE__\\}|\\{__FILE__\\}|\\{__FILEDIR__\\}|\\{__LINE__\\}|\\{__TIME__\\}|\\{__TIMESTAMP__\\}|ADMINTOOLS|APPDATA|CDBURN_AREA|CMDLINE|COMMONFILES|COOKIES|DESKTOP|DOCUMENTS|EXEDIR|EXEFILE|EXEPATH|FAVORITES|FONTS|HISTORY|HWNDPARENT|INSTDIR|INTERNET_CACHE|LANGUAGE|LOCALAPPDATA|MUSIC|NETHOOD|NSIS_MAX_STRLEN|NSIS_VERSION|NSISDIR|OUTDIR|PICTURES|PLUGINSDIR|PRINTHOOD|PROFILE|PROGRAMFILES(32|64)?|QUICKLAUNCH|RECENT|RESOURCES_LOCALIZED|RESOURCES|SENDTO|SMPROGRAMS|SMSTARTUP|STARTMENU|SYSDIR|TEMP|TEMPLATES|VIDEOS|WINDIR)\\b",
+          "name": "variable.language.nsis"
+        },
+        {
+          "match": "\\$\\w[\\w\\.]*",
+          "name": "variable.other.nsis"
+        }
+      ]
+    },
+    {
+      "begin": "`",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.nsis"
+        }
+      },
+      "end": "`",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.nsis"
+        }
+      },
+      "name": "string.quoted.back.nsis",
+      "patterns": [
+        {
+          "match": "\\${2}\\w*",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\$\\\\.",
+          "name": "constant.character.escape.nsis"
+        },
+        {
+          "match": "\\${[\\!\\w\\.:\\^-]+}",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "\\$\\([\\!\\w\\.:\\^-]+\\)",
+          "name": "constant.other.nsis"
+        },
+        {
+          "match": "(?i)\\$(\\{__DATE__\\}|\\{__FILE__\\}|\\{__FILEDIR__\\}|\\{__LINE__\\}|\\{__TIME__\\}|\\{__TIMESTAMP__\\}|ADMINTOOLS|APPDATA|CDBURN_AREA|CMDLINE|COMMONFILES|COOKIES|DESKTOP|DOCUMENTS|EXEDIR|EXEFILE|EXEPATH|FAVORITES|FONTS|HISTORY|HWNDPARENT|INSTDIR|INTERNET_CACHE|LANGUAGE|LOCALAPPDATA|MUSIC|NETHOOD|NSIS_MAX_STRLEN|NSIS_VERSION|NSISDIR|OUTDIR|PICTURES|PLUGINSDIR|PRINTHOOD|PROFILE|PROGRAMFILES(32|64)?|QUICKLAUNCH|RECENT|RESOURCES_LOCALIZED|RESOURCES|SENDTO|SMPROGRAMS|SMSTARTUP|STARTMENU|SYSDIR|TEMP|TEMPLATES|VIDEOS|WINDIR)\\b",
+          "name": "variable.language.nsis"
+        },
+        {
+          "match": "\\$\\w[\\w\\.]*",
+          "name": "variable.other.nsis"
+        }
+      ]
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.comment.nsis"
+        }
+      },
+      "match": "(;|#).*$\\n?",
+      "name": "comment.line.nsis"
+    },
+    {
+      "begin": "/\\*",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.nsis"
+        }
+      },
+      "end": "\\*/",
+      "name": "comment.block.nsis"
+    }
+  ],
+  "scopeName": "source.nsis",
+  "uuid": "B6872F8A-D31D-11E0-9572-0800200C9A66"
+}

--- a/samples/nsis.sample
+++ b/samples/nsis.sample
@@ -1,0 +1,72 @@
+; NSIS Example Installer Script
+
+!include "MUI2.nsh"
+!include "LogicLib.nsh"
+
+!define PRODUCT_NAME "My Application"
+!define PRODUCT_VERSION "1.0.0"
+!define PRODUCT_PUBLISHER "Example Corp"
+
+Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
+OutFile "setup.exe"
+InstallDir "$PROGRAMFILES\${PRODUCT_NAME}"
+InstallDirRegKey HKLM "Software\${PRODUCT_NAME}" "InstallDir"
+RequestExecutionLevel admin
+Unicode true
+
+; Interface settings
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "license.txt"
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_LANGUAGE "English"
+
+/*
+  Main installation section
+*/
+Section "Application Files" SecMain
+  SetOutPath "$INSTDIR"
+
+  File /r "dist\*.*"
+  File "README.md"
+
+  WriteRegStr HKLM "Software\${PRODUCT_NAME}" "InstallDir" "$INSTDIR"
+  WriteRegStr HKLM "Software\${PRODUCT_NAME}" "Version" "${PRODUCT_VERSION}"
+
+  ; Create uninstaller
+  WriteUninstaller "$INSTDIR\uninstall.exe"
+
+  ; Start menu shortcuts
+  CreateDirectory "$SMPROGRAMS\${PRODUCT_NAME}"
+  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME}.lnk" "$INSTDIR\app.exe"
+  CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall.lnk" "$INSTDIR\uninstall.exe"
+SectionEnd
+
+Section "Desktop Shortcut" SecDesktop
+  CreateShortCut "$DESKTOP\${PRODUCT_NAME}.lnk" "$INSTDIR\app.exe"
+SectionEnd
+
+Function .onInit
+  Var /GLOBAL PREV_VERSION
+
+  ReadRegStr $PREV_VERSION HKLM "Software\${PRODUCT_NAME}" "Version"
+
+  ${If} $PREV_VERSION != ""
+    MessageBox MB_YESNO "Version $PREV_VERSION is already installed. Continue?" IDYES +2
+      Abort
+  ${EndIf}
+FunctionEnd
+
+Section "Uninstall"
+  RMDir /r "$INSTDIR"
+  Delete "$DESKTOP\${PRODUCT_NAME}.lnk"
+  RMDir /r "$SMPROGRAMS\${PRODUCT_NAME}"
+  DeleteRegKey HKLM "Software\${PRODUCT_NAME}"
+
+  ${If} ${FileExists} "$APPDATA\${PRODUCT_NAME}"
+    MessageBox MB_YESNO "Remove application data?" IDNO +2
+      RMDir /r "$APPDATA\${PRODUCT_NAME}"
+  ${EndIf}
+SectionEnd

--- a/sources-grammars.ts
+++ b/sources-grammars.ts
@@ -917,6 +917,11 @@ export const sourcesCommunity: GrammarSource[] = [
     source: 'https://github.com/nix-community/vscode-nix-ide/blob/main/dist/nix.tmLanguage.json',
   },
   {
+    name: 'nsis',
+    displayName: 'NSIS',
+    source: 'https://github.com/idleberg/vscode-nsis/blob/main/syntaxes/nsis.tmLanguage',
+  },
+  {
     name: 'nushell',
     aliases: ['nu'],
     source: 'https://github.com/nushell/vscode-nushell-lang/blob/main/syntaxes/nushell.tmLanguage.json',


### PR DESCRIPTION
[NSIS](https://en.wikipedia.org/?title=Nullsoft_Scriptable_Install_System&redirect=no) is a widely used open-source scripting language to create installers for Windows. It has been around since 1997 and is still used in tools such [electron-builder](https://www.electron.build/).

The grammar has its origins in this [Sublime Text repository](https://github.com/SublimeText/NSIS). However, since Sublime Text switched to a new format, I'm maintaining the TextMate format in my [VS Code extension](https://github.com/idleberg/vscode-nsis). Full disclosure: I'm the main contributor to both mentioned repos.

Related: https://github.com/github-linguist/NSIS