### PR TITLE
feat: add `smithy` grammar

### DIFF
--- a/samples/smithy.sample
+++ b/samples/smithy.sample
@@ -1,0 +1,138 @@
+$version: "2"
+
+namespace example.weather
+
+/// Provides weather forecasts.
+@paginated(inputToken: "nextToken", outputToken: "nextToken", pageSize: "pageSize")
+service Weather {
+    version: "2006-03-01"
+    resources: [
+        City
+    ]
+    operations: [
+        GetCurrentTime
+    ]
+}
+
+resource City {
+    identifiers: { cityId: CityId }
+    properties: { coordinates: CityCoordinates }
+    read: GetCity
+    list: ListCities
+    resources: [
+        Forecast
+    ]
+}
+
+resource Forecast {
+    identifiers: { cityId: CityId }
+    properties: { chanceOfRain: Float }
+    read: GetForecast
+}
+
+// "pattern" is a trait.
+@pattern("^[A-Za-z0-9 ]+$")
+string CityId
+
+@readonly
+operation GetCity {
+    input := for City {
+        // "cityId" provides the identifier for the resource and
+        // has to be marked as required.
+        @required
+        $cityId
+    }
+
+    output := for City {
+        // "required" is used on output to indicate if the service
+        // will always provide a value for the member.
+        @required
+        @notProperty
+        name: String
+
+        @required
+        $coordinates
+    }
+
+    errors: [
+        NoSuchResource
+    ]
+}
+
+// This structure is nested within GetCityOutput.
+structure CityCoordinates {
+    @required
+    latitude: Float
+
+    @required
+    longitude: Float
+}
+
+// "error" is a trait that is used to specialize
+// a structure as an error.
+@error("client")
+structure NoSuchResource {
+    @required
+    resourceType: String
+}
+
+// The paginated trait indicates that the operation may
+// return truncated results.
+@readonly
+@paginated(items: "items")
+operation ListCities {
+    input := {
+        nextToken: String
+        pageSize: Integer
+    }
+
+    output := {
+        nextToken: String
+
+        @required
+        items: CitySummaries
+    }
+}
+
+// CitySummaries is a list of CitySummary structures.
+list CitySummaries {
+    member: CitySummary
+}
+
+// CitySummary contains a reference to a City.
+@references([
+    {
+        resource: City
+    }
+])
+structure CitySummary {
+    @required
+    cityId: CityId
+
+    @required
+    name: String
+}
+
+@readonly
+operation GetCurrentTime {
+    output := {
+        @required
+        time: Timestamp
+    }
+}
+
+@readonly
+operation GetForecast {
+    input := for Forecast {
+        // "cityId" provides the only identifier for the resource since
+        // a Forecast doesn't have its own.
+        @required
+        $cityId
+    }
+
+    output := for Forecast {
+        $chanceOfRain
+    }
+}
+
+// From https://github.com/smithy-lang/smithy-examples/blob/main/quickstart-examples/quickstart-cli/models/weather.smithy

--- a/sources-grammars.ts
+++ b/sources-grammars.ts
@@ -1073,6 +1073,14 @@ export const sourcesCommunity: GrammarSource[] = [
     source: 'https://github.com/leocamello/vscode-smalltalk/blob/master/syntaxes/smalltalk.tmLanguage.json',
   },
   {
+    name: 'smithy',
+    displayName: 'Smithy',
+    source: 'https://github.com/smithy-lang/smithy-vscode/blob/main/syntaxes/smithy.tmLanguage.json',
+    categories: ['web'],
+    license: 'Apache-2.0',
+    licenseUrl: 'https://github.com/smithy-lang/smithy-vscode/blob/main/LICENSE',
+  },
+  {
     name: 'solidity',
     source: 'https://github.com/juanfranblanco/vscode-solidity/blob/master/syntaxes/solidity.json',
   },


### PR DESCRIPTION
[Smithy](https://smithy.io/index.html) is an interface definition language used to define web services and generate clients, servers, and other kinds of artifacts through model transformations. Notably it is used by AWS to generate the official SDks, though it is not limited to AWS. A number of Smithy projects can be found in the [smithy-lang GitHub org](https://github.com/smithy-lang).

Smithy's grammar has been [supported by linguist](https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml#L7527) for a while now.