### PR TITLE
feat(grammars): add SystemVerilog aliases

### DIFF
--- a/sources-grammars.ts
+++ b/sources-grammars.ts
@@ -1143,6 +1143,8 @@ export const sourcesCommunity: GrammarSource[] = [
   },
   {
     name: 'system-verilog',
+    displayName: 'SystemVerilog',
+    aliases: ['sv', 'systemverilog'],
     source: 'https://github.com/mshr-h/vscode-verilog-hdl-support/blob/main/syntaxes/systemverilog.tmLanguage.json',
   },
   {


### PR DESCRIPTION
Add `sv` and `systemverilog` aliases for the SystemVerilog grammar and set its display name to `SystemVerilog`.